### PR TITLE
Transform event content for API endpoint calls

### DIFF
--- a/runtime.R
+++ b/runtime.R
@@ -89,7 +89,7 @@ handle_event <- function(event) {
     Sys.setenv("_X_AMZN_TRACE_ID" = runtime_trace_id)
   }
 
-  # we need to parse the event in four contexts before sending to the handler:
+  # we need to parse the event in four contexts before sending to the lambda fn:
   # 1a) direct invocation with no function args (empty event)
   # 1b) direct invocation with function args (parse and send entire event)
   # 2a) api endpoint with no args (parse HTTP request, confirm null request
@@ -114,8 +114,8 @@ handle_event <- function(event) {
   # other http request elements if it's an endpoint), you can do that here!
   
   # change `http_req_element` if you'd prefer to send the http request `body` to
-  # the handler, rather than the query parameters
-  # (note that query string params are always strings! your handler fn may need to
+  # the lambda fn, rather than the query parameters
+  # (note that query string params are always strings! your lambda fn may need to
   # convert them back to numeric/logical/Date/etc.)
   is_http_req <- FALSE
   http_req_element <- "queryStringParameters"
@@ -131,7 +131,6 @@ handle_event <- function(event) {
     }
   }
   
-
   result <- do.call(function_name, event_content)
   log_debug("Result:", as.character(result))
   response_endpoint <- paste0(

--- a/runtime.R
+++ b/runtime.R
@@ -137,9 +137,19 @@ handle_event <- function(event) {
     "http://", lambda_runtime_api, "/2018-06-01/runtime/invocation/",
     aws_request_id, "/response"
   )
+  # aws api gateway is a bit particular about the response format
+  body <- if (is_http_req) {
+    list(
+      isBase64Encoded = FALSE,
+      statusCode = 200L,
+      body = result
+      )
+  } else {
+    result
+  }
   POST(
     url = response_endpoint,
-    body = result,
+    body = body,
     encode = "json"
   )
   rm("aws_request_id") # so we don't report errors to an outdated endpoint


### PR DESCRIPTION
Passes query string parameters to the Lambda fn instead of the whole event in the case that an HTTP request with query string params comes through. If it's an API request with no query string parameters, that JSON element is `null`, and so the Lambda fn gets an empty `list()` (just like direct invocation with no args).

I've left a note in there with instructions on changing it if the user would prefer to pass the request _body_ in to the Lambda function arguments instead of the query string parameters. It works the same way in principle, though, if the body is JSON.

**Note that query string parameters are always interpreted as strings, so the Lambda fn needs to explicitly convert them to the intended type.**

This still doesn't quite cut it for API Gateway: although good Lambda calls POST 200 OK, the API Gateway receives it and sends on "502: Malformed Lambda proxy response". See:
  * https://aws.amazon.com/premiumsupport/knowledge-center/malformed-502-api-gateway
  * https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format

I'm not sure how to alter the POST response yet, though!