### PR TITLE
Improved error handling and API Gateway integration

### DIFF
--- a/runtime.R
+++ b/runtime.R
@@ -196,7 +196,6 @@ while (TRUE) {
           body = list(
             statusCode = e$code,
             error_message = as.character(e$message)),
-          verbose(),
           encode = "json"
         )
       } else {
@@ -217,7 +216,6 @@ while (TRUE) {
         POST(
           url = invocation_error_endpoint,
           body = list(error_message = as.character(e)),
-          verbose(),
           encode = "json"
         )
       } else {

--- a/runtime.R
+++ b/runtime.R
@@ -89,7 +89,7 @@ handle_event <- function(event) {
     Sys.setenv("_X_AMZN_TRACE_ID" = runtime_trace_id)
   }
 
-  # we need to parse the event in four contexts before sending to the handler:
+  # we need to parse the event in four contexts before sending to the lambda fn:
   # 1a) direct invocation with no function args (empty event)
   # 1b) direct invocation with function args (parse and send entire event)
   # 2a) api endpoint with no args (parse HTTP request, confirm null request
@@ -114,8 +114,8 @@ handle_event <- function(event) {
   # other http request elements if it's an endpoint), you can do that here!
   
   # change `http_req_element` if you'd prefer to send the http request `body` to
-  # the handler, rather than the query parameters
-  # (note that query string params are always strings! your handler fn may need to
+  # the lambda fn, rather than the query parameters
+  # (note that query string params are always strings! your lambda fn may need to
   # convert them back to numeric/logical/Date/etc.)
   is_http_req <- FALSE
   http_req_element <- "queryStringParameters"
@@ -131,7 +131,6 @@ handle_event <- function(event) {
     }
   }
   
-
   result <- do.call(function_name, event_content)
   log_debug("Result:", as.character(result))
   response_endpoint <- paste0(

--- a/runtime.R
+++ b/runtime.R
@@ -118,7 +118,7 @@ handle_event <- function(event) {
   unparsed_content <- httr::content(event, "text", encoding = "UTF-8")
   # Thank you to Menno Schellekens for this fix for Cloudwatch events
   is_scheduled_event <- grepl("Scheduled Event", unparsed_content)
-  if(is_scheduled_event) log_info("Event type is scheduled") 
+  if(is_scheduled_event) log_info("Event type is scheduled")
   log_debug("Unparsed content:", unparsed_content)
   if (unparsed_content == "" || is_scheduled_event) {
     # (1a) direct invocation with no args (or scheduled request)
@@ -160,7 +160,7 @@ handle_event <- function(event) {
     list(
       isBase64Encoded = FALSE,
       statusCode = 200L,
-      body = result
+      body =  as.character(jsonlite::toJSON(result))
       )
   } else {
     result

--- a/runtime.R
+++ b/runtime.R
@@ -160,7 +160,7 @@ handle_event <- function(event) {
     list(
       isBase64Encoded = FALSE,
       statusCode = 200L,
-      body =  as.character(jsonlite::toJSON(result))
+      body =  as.character(jsonlite::toJSON(result, auto_unbox = TRUE))
       )
   } else {
     result

--- a/runtime.R
+++ b/runtime.R
@@ -1,7 +1,7 @@
 library(httr)
 library(logger)
 log_formatter(formatter_paste)
-log_threshold(DEBUG)
+log_threshold(INFO)
 
 #' Convert a list to a single character, preserving names
 #' prettify_list(list("a" = 1, "b" = 2, "c" = 3))
@@ -11,6 +11,20 @@ prettify_list <- function(x) {
     paste(names(x), x, sep = "="),
     collapse = ", "
   )
+}
+
+# error handling with http codes
+# from http://adv-r.had.co.nz/Exceptions-Debugging.html
+condition <- function(subclass, message, code, call = sys.call(-1), ...) {
+  structure(
+    class = c(subclass, "condition"),
+    list(message = message, code = code, call = call),
+    ...
+  )
+}
+stop_api <- function(message, code = 500, call = sys.call(-1), ...) {
+  stop(condition(c("api_error", "error"), message, code = code, call = call,
+    ...))
 }
 
 log_debug("Deriving lambda runtime API endpoints from environment variables")
@@ -32,7 +46,7 @@ tryCatch(
     log_debug("Determining handler from environment variables")
     handler <- Sys.getenv("_HANDLER")
     if (is.null(handler) || handler == "") {
-      stop("_HANDLER environment variable undefined")
+      stop_api("_HANDLER environment variable undefined")
     }
     log_info("Handler found:", handler)
     handler_split <- strsplit(handler, ".", fixed = TRUE)[[1]]
@@ -42,24 +56,26 @@ tryCatch(
 
     log_debug("Checking if", file_name, "exists")
     if (!file.exists(file_name)) {
-      stop(file_name, " doesn't exist in ", getwd())
+      stop_api(file_name, " doesn't exist in ", getwd())
     }
     source(file_name)
 
     log_debug("Checking if", function_name, "is defined")
     if (!exists(function_name)) {
-      stop("Function name ", function_name, " isn't defined in R")
+      stop_api("Function name ", function_name, " isn't defined in R")
     }
     log_debug("Checking if", function_name, "is a function")
     if (!is.function(eval(parse(text = function_name)))) {
-      stop("Function name ", function_name, " is not a function")
+      stop_api("Function name ", function_name, " is not a function")
     }
   },
-  error = function(e) {
+  api_error = function(e) {
     log_error(as.character(e))
     POST(
       url = initialisation_error_endpoint,
-      body = list(error_message = as.character(e)),
+      body = list(
+        statusCode = e$code,
+        error_message = as.character(e$message)),
       encode = "json"
     )
     stop(e)
@@ -70,7 +86,8 @@ handle_event <- function(event) {
   status_code <- status_code(event)
   log_debug("Status code:", status_code)
   if (status_code != 200) {
-    stop("Didn't get status code 200. Status code: ", status_code)
+    stop_api("Didn't get status code 200. Status code: ", status_code,
+      code = 400)
   }
   event_headers <- headers(event)
 
@@ -80,7 +97,8 @@ handle_event <- function(event) {
 
   aws_request_id <- event_headers[["lambda-runtime-aws-request-id"]]
   if (is.null(aws_request_id)) {
-    stop("Could not find lambda-runtime-aws-request-id header in event")
+    stop_api("Could not find lambda-runtime-aws-request-id header in event",
+      code = 400)
   }
 
   # According to the AWS guide, the below is used by "X-Ray SDK"
@@ -162,6 +180,29 @@ while (TRUE) {
       event <- GET(url = next_invocation_endpoint)
       log_debug("Event received")
       handle_event(event)
+    },
+     api_error = function(e) {
+      log_error(as.character(e))
+      aws_request_id <-
+        headers(event)[["lambda-runtime-aws-request-id"]]
+      if (exists("aws_request_id")) {
+        log_debug("POSTing invocation error for ID:", aws_request_id)
+        invocation_error_endpoint <- paste0(
+          "http://", lambda_runtime_api, "/2018-06-01/runtime/invocation/",
+          aws_request_id, "/error"
+        )
+        POST(
+          url = invocation_error_endpoint,
+          body = list(
+            statusCode = e$code,
+            error_message = as.character(e$message)),
+          verbose(),
+          encode = "json"
+        )
+      } else {
+        log_debug("No invocation ID!",
+          "Can't clear this request from the queue.")
+      }
     },
     error = function(e) {
       log_error(as.character(e))

--- a/runtime.R
+++ b/runtime.R
@@ -137,9 +137,19 @@ handle_event <- function(event) {
     "http://", lambda_runtime_api, "/2018-06-01/runtime/invocation/",
     aws_request_id, "/response"
   )
+  # aws api gateway is a bit particular about the response format
+  body <- if (is_http_req) {
+    list(
+      isBase64Encoded = FALSE,
+      statusCode = 200L,
+      body = result
+      )
+  } else {
+    result
+  }
   POST(
     url = response_endpoint,
-    body = result,
+    body = body,
     encode = "json"
   )
   rm("aws_request_id") # so we don't report errors to an outdated endpoint


### PR DESCRIPTION
This PR has a few changes:

1. Improves the existing error handling so that R doesn't have to be terminated (thereby allowing subsequent requests to be processed even after an error); and 
2. Defines a drop-in replacement for `stop`, `stop_api`, that allows Lambda functions or the runtime to pass an HTTP error code along with an error message (so that the API Gateway can pass the error code along to the user). This allows, for example, bad user input (code 400) to be distinguished from an unexpected server error (code 500).
3. Modifies the request handler to pass query string parameters to the Lambda fn instead of the whole event in the case that an HTTP request with query string params comes through. If it's an API request with no query string parameters, that JSON element is null, and so the Lambda fn gets an empty list() (just like direct invocation with no args).
4. Modifies the POST in the request handler to be compatible with 

Change 1 essentially re-extracts the AWS request ID from the event. It's extracted inside the request handler, but it doesn't appear to still be in scope in the error handler, so the error is never POSTed and cleared from the queue. The existing solution to this is to call `stop` again, but this terminates R, so the runtime is no longer responsive to subsequent requests. By re-extracting, we can properly POST, clearing it from the queue, so we don't need to kill R.

Changes 2 and 4 are required because API Gateway [is very particular about the format of the responses it receives](https://aws.amazon.com/premiumsupport/knowledge-center/malformed-502-api-gateway). It forwards the response on to the user, so it expects you to pass your entire response (body, status code and any headers) on as the body of the response to it (encoded in JSON). If the response is malformed, it passes a generic 502 "Internal server error" back to the user.

Here's an example of how a Lambda function might use Change 2:

```r
evenOnly <- function(n) {
  if (n %% 2 == 1) {
    stop_api("Even numbers only!", code = 400)
  }
  paste(n, "is a lovely number!")
}
```

I've left a note in the request handler with instructions on customising it if the user would prefer to pass the request body in to the Lambda function arguments instead of the query string parameters. It works the same way in principle, though, if the body is JSON. (Note that query string parameters are always interpreted as strings, so the Lambda fn needs to explicitly convert them to the intended type.)